### PR TITLE
Removed contact page from title bar. Don't want it

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,6 @@ urls:
       url: /gallery
     - text: Schmorbonium
       url : https://schmorbonium.github.io/project-website
-    - text: Contact
-      url : /contact
 
 
 # Edit Author details (For multi authors check _data/authors.yml)


### PR DESCRIPTION
I don't want to deal with the contact form and what happens behind the scenes. Not removing it permanently. It's just not going to be accessible.